### PR TITLE
Add support local dependencies to Component plugin

### DIFF
--- a/plugin/component.js
+++ b/plugin/component.js
@@ -88,9 +88,20 @@
           var dep = Object.keys(cmp.dependencies).filter(function(dependency) {
             return dpx.test(dependency);
           }).pop();
-          var author = dep.match(/(.*?)\/.*?/i).shift();
-          author =  author.substring(0, author.length - 1);
-          file = resolve(dir, "components/" + author + "-" + name);
+          if (cmp.local.indexOf(name) !== -1) {
+            if (cmp.paths) {
+              cmp.paths.some(function (path) {
+                file = resolve(dir, [path, name].join('/'));
+                if (file) return true;
+              });
+            } else {
+              file = resolve(dir, name);
+            }
+          } else if (dep) {
+            var author = dep.match(/(.*?)\/.*?/i).shift();
+            author = author.substring(0, author.length - 1);
+            file = resolve(dir, "components/" + author + "-" + name);
+          }
         } catch(e) {}
       }
 

--- a/test/cases/component/component.json
+++ b/test/cases/component/component.json
@@ -1,5 +1,7 @@
 {
   "dependencies": {
     "marijnh/tern": "*"
-  }
+  },
+  "paths": ["lib"],
+  "local": ["local-component"]
 }

--- a/test/cases/component/lib/local-component/component.json
+++ b/test/cases/component/lib/local-component/component.json
@@ -1,0 +1,3 @@
+{
+  "main": "index.js"
+}

--- a/test/cases/component/lib/local-component/index.js
+++ b/test/cases/component/lib/local-component/index.js
@@ -1,0 +1,1 @@
+exports.hi = function() { return 'hi'; };

--- a/test/cases/component/main.js
+++ b/test/cases/component/main.js
@@ -2,3 +2,4 @@
 
 require('./localfile').hey; //: fn() -> string
 require('tern').hello; //: fn() -> number
+require('local-component').hi; //: fn() -> string


### PR DESCRIPTION
Component has [the notion of "local dependencies"](https://github.com/component/component/wiki/Spec#local), which can be defined inside of `component.json`.

I realise that currently [the Component plugin](https://github.com/marijnh/tern/pull/239) does not support these.