### PR TITLE
plugin/node: `definition` for `require()`

### DIFF
--- a/test/cases/node/main.js
+++ b/test/cases/node/main.js
@@ -74,3 +74,6 @@ module.exports. //+
 require('f //+ 'fs'
 // completion on custom require module
 require("my //+ "mymod"
+
+// go to definition for modulest
+require('./localfile'//loc: 1, 0, localfile.js

--- a/test/condense/node_other_module_type_ref.json
+++ b/test/condense/node_other_module_type_ref.json
@@ -2,12 +2,14 @@
   "!define": {
     "!node": {
       "node_export_function_a`js": {
+        "!span": "0[0:0]-26[1:0]",
         "a": {
           "!span": "8[0:8]-9[0:9]",
           "!type": "fn()"
         }
       },
       "node_other_module_type_ref`js": {
+        "!span": "0[0:0]-51[1:0]",
         "b": "!node.node_export_function_a`js.a"
       }
     }

--- a/test/condense/node_simple.json
+++ b/test/condense/node_simple.json
@@ -2,6 +2,7 @@
   "!define": {
     "!node": {
       "node_simple`js": {
+        "!span": "0[0:0]-62[2:0]",
         "a": {
           "!span": "8[0:8]-9[0:9]",
           "!type": "number"

--- a/test/runcases.js
+++ b/test/runcases.js
@@ -150,12 +150,14 @@ exports.runTests = function(filter, caseDir) {
                    "instead of expected docstring\n  " + args);
             }
           } else if (kind == "loc:") { // Definition finding test
-            var pos = args.match(/^\s*(\d+),\s*(\d+)/), line = Number(pos[1]), col = Number(pos[2]);
+            var pos = args.match(/^\s*(\d+),\s*(\d+)(?:,\s*([^,]+))?/), line = Number(pos[1]), col = Number(pos[2]), file = pos[3];
+            var actualLoc = (file ? resp.origin + ":" : "") + (resp.start.line + 1) + ":" + resp.start.ch;
+            var expectedLoc = (file ? file + ":" : "") + line + ":" + col;
             if (!resp.start)
-              fail(m, "Did not find a definition.");
-            else if (resp.start.line + 1 != line || resp.start.ch != col)
-              fail(m, "Found definition at " + (resp.start.line + 1) + ":" + resp.start.ch +
-                   " instead of expected " + line + ":" + col);
+              fail(m, "Did not find a definition (expected " + expectedLoc + ").");
+            else if (resp.start.line + 1 != line || resp.start.ch != col || (file && file !== resp.origin))
+              fail(m, "Found definition at " + actualLoc +
+                   " instead of expected " + expectedLoc);
           } else if (kind == "origin:") { // Origin finding test
             if (resp.origin != args)
               fail(m, "Found origin\n  " + resp.origin + "\ninstead of expected origin\n  " + args);


### PR DESCRIPTION
Enhance the node plugin to decorate string literals passed to `require` calls so that `definition` queries for these literals return results pointing to `module.exports` in the target files.

Example:

```js
var express = require('express');
```

Place the cursor inside the `express` string and invoke `:TernDef` in Vim. With this change in place, Vim navigates to `node_modules/express/index.js`.

This functionality is already available in WebStorm and possibly in other IDEs too.