### PR TITLE
Move position of doc property

### DIFF
--- a/lib/condense.js
+++ b/lib/condense.js
@@ -200,7 +200,7 @@
       if (protoName != "?") out["!proto"] = protoName;
     }
     if (info.span) out["!span"] = info.span;
-    if (info.doc) out["!doc"] = info.doc;
+    if (info.type.doc) out["!doc"] = info.type.doc;
     if (info.data) out["!data"] = info.data;
   }
 


### PR DESCRIPTION
I'm not totally confident that this should be fixed here, or if it's a regression
elsewhere, but I'm seeing the docstring of JSDoc comments living _under_ the
type property.