### PR TITLE
Deleting CR to adjust the text position to editor

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -73,9 +73,9 @@
   File.prototype.asLineChar = function(pos) { return asLineChar(this, pos); };
 
   function updateText(file, text, srv) {
-    file.text = text;
+    file.text = text.replace(/\r/g,""); // adjust text position to editor
     infer.withContext(srv.cx, function() {
-      file.ast = infer.parse(text, srv.passes, {directSourceFile: file, allowReturnOutsideFunction: true});
+      file.ast = infer.parse(file.text, srv.passes, {directSourceFile: file, allowReturnOutsideFunction: true});
     });
     file.lineOffsets = null;
   }


### PR DESCRIPTION
Issue #467
If the source code is encoded in DOS-like line separator,
Emacs reports incorrect type definition or throw errors.
It is caused by the difference of handling EOL between Emacs and
node.js, Emacs treats CRLF as one character, but node.js does as 2
characters.

This patch deletes the CR character from the source codes
which are loaded on the memory and adjust to Emacs handling.

I checked this patch on Emacs 24.3/Linux, Vim 7.4.542/Linux, NTEmacs 24.4/Windows8 and Vim7.4(kaoriya)/Windows8.