### PR TITLE
Improve document#createElement by returning teh well HTML Element instance

### DIFF
--- a/defs/browser.json
+++ b/defs/browser.json
@@ -1337,8 +1337,17 @@
     "!url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLDataListElement"
   },
   "HTMLDivElement": {
-    "!type": "Element",
-    "!url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement"
+    "!type": "fn()",
+    "prototype": {
+      "!proto": "Element.prototype",
+      "align": {
+        "!type": "string",
+        "!url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement",
+        "!doc": "numerated property indicating alignment of the element's contents with respect to the surrounding context. The possible values are 'left', 'right', 'justify', and 'center'."
+      }
+    },
+    "!url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement",
+    "!doc": "The HTMLDivElement interface provides special properties (beyond the regular HTMLElement interface it also has available to it by inheritance) for manipulating div elements."
   },
   "HTMLDListElement": {
     "!type": "Element",

--- a/defs/browser.json
+++ b/defs/browser.json
@@ -1086,7 +1086,7 @@
         "!doc": "Returns a Boolean value indicating whether the document or any element inside the document has focus. This method can be used to determine whether the active element in a document has focus."
       },
       "createElement": {
-        "!type": "fn(tagName: string) -> +Element",
+        "!type": "fn(tagName: string) -> !custom:Browser_createElement",
         "!url": "https://developer.mozilla.org/en/docs/DOM/document.createElement",
         "!doc": "Creates the specified element."
       },

--- a/lib/def.js
+++ b/lib/def.js
@@ -494,6 +494,22 @@
     }
     return arr;
   });
+  
+  infer.registerFunction("Browser_createElement", function(_self, args, argNodes) {
+	var getHTMLElementName = function(name) {
+	 if (!name) return;
+	 if (name.length < 1) return;
+	 return "HTML" + name.charAt(0).toUpperCase() + name.substring(1, name.length).toLowerCase() + "Element"; 
+	}
+	  
+	var createElement = function(name) {
+	  var cx = infer.cx(), eltName = name ? getHTMLElementName(name) : "Element";
+	  if (!cx.topScope.hasProp(eltName)) eltName = "Element";
+	  return new infer.Obj(infer.def.parsePath(eltName + ".prototype", null).getType());
+	}	  
+    return createElement(argNodes && argNodes.length && argNodes[0] &&  
+        (argNodes[0].type == "Literal" || typeof argNodes[0].value == "string") ? argNodes[0].value : "Element");
+  });  
 
   return exports;
 });

--- a/test/cases/browser.js
+++ b/test/cases/browser.js
@@ -1,8 +1,9 @@
 // environment=browser
 
 window.document.body; //: Element
+var anyElt = document.createElement("any"); //: Element
 
-var newElt = document.createElement("div"); //: Element
+var newElt = document.createElement("div"); //: HTMLDivElement
 
 newElt.style.border; //: string
 


### PR DESCRIPTION
This PR gives the capability to return the well HTML instance according the createElement parameter : 

 * here a sample with any element : 
```javascript
var elt = document.createElement('any') // here elt is an instance of Element
```

 * here a sample with HTML div : 

```javascript
var div= document.createElement('div') // here elt is an instance of HTMLDivElement
div.a // Ctrl+Space shows align attribute (only available for div).
```

To support that, I needed to create a tern function `Browser_createElement` that I have added inside `def.js`. It's not very clean. I think `brower.json` should be tranformed to a tern plugin `browser.js`.