### PR TITLE
invoke completion-at-point with C-TAB

### DIFF
--- a/emacs/tern.el
+++ b/emacs/tern.el
@@ -537,6 +537,7 @@ list of strings, giving the binary name and arguments.")
       (tern-send-buffer-to-server))))
 
 (defvar tern-mode-keymap (make-sparse-keymap))
+(define-key tern-mode-keymap [(control tab)] 'completion-at-point)
 (define-key tern-mode-keymap [(meta ?.)] 'tern-find-definition)
 (define-key tern-mode-keymap [(control meta ?.)] 'tern-find-definition-by-name)
 (define-key tern-mode-keymap [(meta ?,)] 'tern-pop-find-definition)


### PR DESCRIPTION
First : thank you Marjin for both "Eloquent JavaScript" and Ternjs. I owe you a lot for these.
Second: My tern auto complete didn't work as I expected since the default M-TAB invokes OS application  switch key (I use Ubuntu 14.04). I wanted to use  js3-mode, Auto complete(TAB), Yasnippet  (I put it to shift-TAB so it wont conflict with auto) and Tern (I want to invoke it with C-TAB and . )  so I added 

        (define-key tern-mode-keymap [(control tab)] 'completion-at-point)

in keymap section of code. Which I think will help many who are new to Emacs. 
Now I can get all these great packages together. and who needs WebStorm any more :).

https://github.com/dshamaeli/My-Emacs.git 
 