### PR TITLE
Getting code completion to work with custom Types

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -622,7 +622,7 @@
       completions.push(rec);
 
       if (obj && (query.types || query.docs || query.urls || query.origins)) {
-        var val = obj.props[prop];
+        var val = obj.getProp(prop);
         infer.resetGuessing();
         var type = val.getType();
         rec.guess = infer.didGuess();


### PR DESCRIPTION
The gather callback obviously expected the reported obj in the gather callback to be an instance of infer.Obj and directly uses its implementation private "props" property in "obj.props[]". Instead I believe it should use the proper API "obj.getProp()". This bit me when I tried to implement my own static Type that did not have the "props" field. The proposed change makes the implementation accept custom "infer.Type" implementations, too.