### PR TITLE
Always glob in the root of the project

### DIFF
--- a/bin/tern
+++ b/bin/tern
@@ -151,7 +151,7 @@ function startServer(dir, config) {
   });
 
   if (config.loadEagerly) config.loadEagerly.forEach(function(pat) {
-    glob.sync(pat).forEach(function(file) {
+    glob.sync(pat, { cwd: dir }).forEach(function(file) {
       server.addFile(file);
     });
   });


### PR DESCRIPTION
`glob.sync` defaults its search to the current working directory. When used from the Sublime Text 3 plugin, the current working directory becomes the path of the first opened file. This is incorrect, the `loadEagerly` property is intended to load files relative to the root (or `.tern-project` file).