### PR TITLE
pin acorn dep so that breaking acorn changes don’t break tern

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "sh -c './bin/test'"
   },
   "dependencies": {
-    "acorn": ">=1.0.1",
+    "acorn": "^1.0.1",
     "glob": "3",
     "minimatch": "0.2",
     "typescript": "=1.0.1"


### PR DESCRIPTION

In our build last night (which runs a clean npm install), we got the following failures when trying to browserify tern.js:

```
Error: module "acorn/acorn" not found from "[...]/node_modules/tern/lib/tern.js"
Error: module "acorn/util/walk" not found from "[...]/node_modules/tern/lib/tern.js"
```

After debugging I found that tern 0.9.0 depends on "acorn":">=0.12.0" and is now installing acorn@1.0.1 which appears to have a different path structure.

I see that you're in the process of releasing a new tern, but I wanted to help avoid this problem in the future.

---

This pull request pins acorn to non-breaking changes of acorn. Reason for this is below.

It is effectively equivalent to acorn >=1.0.1 && <2.0.0, see https://github.com/npm/node-semver#caret-ranges-123-025-004

If instead you prefer acorn >=1.0.1 && <1.1.0, I can change it to ~: https://github.com/npm/node-semver#tilde-ranges-123-12-1