### PR TITLE
Mark the type which is coming from the comment

### DIFF
--- a/plugin/doc_comment.js
+++ b/plugin/doc_comment.js
@@ -369,6 +369,7 @@
   function propagateWithWeight(type, target) {
     var weight = infer.cx().parent._docComment.weight;
     type.type.propagate(target, weight || (type.madeUp ? WG_MADEUP : undefined));
+     type.type.fromComment = true; // mark the type is coming from the comment
   }
 
   function applyType(type, self, args, ret, node, aval) {


### PR DESCRIPTION
This PR gives the capability to know if a type is created from a comment or not.

In my case I need this information to support validation with comments https://github.com/angelozerr/tern-lint/issues/30