### PR TITLE
[emacs mode] Fix AC error when type info is null

### DIFF
--- a/emacs/tern-auto-complete.el
+++ b/emacs/tern-auto-complete.el
@@ -86,9 +86,9 @@
            (name (cdr (assq 'name item))))
        (popup-make-item
         name
-        :symbol (if (string-match "fn" type) "f" "v")
+        :symbol (if (null type) "?" (if (string-match "fn" type) "f" "v"))
         :summary (truncate-string-to-width
-                  type tern-ac-completion-truncate-length 0 nil "...")
+                  (or type "?") tern-ac-completion-truncate-length 0 nil "...")
         :document (concat type "\n\n" doc))))
    tern-ac-complete-reply))
 


### PR DESCRIPTION
When the tern server returns completion items which have null type field, emacs raises following error message:

```
Error running timer `ac-show-menu': (wrong-type-argument stringp nil)
Error running timer `ac-update-greedy': (wrong-type-argument stringp nil)
```

This patch fixes this problem and display the items appropriately.