### PR TITLE
A typo in tern.el comments

### DIFF
--- a/emacs/tern.el
+++ b/emacs/tern.el
@@ -384,7 +384,7 @@ list of strings, giving the binary name and arguments.")
 
 ;; Highlight references in scope
 
-(defvar tern-flash-timeout 0.5 "Delay before highlight overlay dissappears.")
+(defvar tern-flash-timeout 0.5 "Delay before the highlight overlay disappears.")
 
 (defun tern-flash-region (start end)
   "Temporarily highlight region from START to END."


### PR DESCRIPTION
`dissappears` → `disappears`. Plus, added `the`.

(I started using `flyspell-prog-mode` :smile:)