### PR TITLE
Add option to make tern completions synchronous.

### DIFF
--- a/emacs/tern-auto-complete.el
+++ b/emacs/tern-auto-complete.el
@@ -37,6 +37,16 @@
   :type 'boolean
   :group 'auto-complete)
 
+(defcustom tern-ac-sync t
+  "[AC] If t, auto-complete will wait for tern canditates before starting.
+This enables tern canditates to integrate automatically in auto-complete without
+the need for a separate keybinding.
+
+Remember to add ac-source-tern-completion to ac-sources."
+  :type 'boolean
+  :group 'auto-complete)
+
+
 (defvar tern-ac-complete-reply nil  "[internal] tern-ac-complete-reply.")
 
 (defvar tern-ac-complete-request-point 0
@@ -110,6 +120,15 @@
   (if tern-ac-on-dot
       (define-key tern-mode-keymap "." 'tern-ac-dot-complete)
     (define-key tern-mode-keymap "." nil)))
+
+(defadvice auto-complete (around add-tern-ac-candidates first activate)
+  "Load tern-js canditates before ac-start."
+  (if (and tern-ac-sync
+           (memq major-mode '(js2-mode js-mode javascript-mode))
+           (not (or (ac-menu-live-p) (ac-inline-live-p))))
+      (tern-ac-complete-request
+       'auto-complete-1)
+    ad-do-it))
 
 
 (provide 'tern-auto-complete)


### PR DESCRIPTION
With this option on there is no need to bind a separate key specifically
for tern-ac-complete, it will be queried automatically by auto-complete
and list completions along with other ac-sources.