### PR TITLE
Add angular $q constructor type info

### DIFF
--- a/plugin/angular.js
+++ b/plugin/angular.js
@@ -641,6 +641,7 @@
           "!doc": "Converts Angular expression into a function."
         },
         $q: {
+          "!type": "fn(executor: fn(resolve: fn(value: ?) -> +Promise, reject: fn(value: ?) -> +Promise)) -> +Promise",
           "!url": "http://docs.angularjs.org/api/ng.$q",
           "!doc": "A promise/deferred implementation.",
           all: {


### PR DESCRIPTION
A minor bug fix to add the `$q` "constructor" type info as described here:
* http://docs.angularjs.org/api/ng.$q

This prevents erroneous complaints about the misuse of `$q` when using the `angular` and `lint` plugins.