### PR TITLE
Provide a preParse event (to support HTML files)

### DIFF
--- a/doc/src/manual.txt
+++ b/doc/src/manual.txt
@@ -815,7 +815,7 @@ object.
 To push code into a context, you first parse it, yielding a syntax
 tree, and then tell Tern to analyze that.
 
-[[infer.parse]]`infer.parse(text: string) → AST`:: Parse a piece of
+[[infer.parse]]`infer.parse(file: File, text: string, passes: [], options?: {}) → AST`:: Parse a piece of
 code for use by Tern. Will automatically fall back to the
 error-tolerant parser if the regular parser can't parse the code.
 

--- a/doc/src/manual.txt
+++ b/doc/src/manual.txt
@@ -815,7 +815,7 @@ object.
 To push code into a context, you first parse it, yielding a syntax
 tree, and then tell Tern to analyze that.
 
-[[infer.parse]]`infer.parse(file: File, text: string, passes: [], options?: {}) → AST`:: Parse a piece of
+[[infer.parse]]`infer.parse(text: string, passes: [], options?: {}) → AST`:: Parse a piece of
 code for use by Tern. Will automatically fall back to the
 error-tolerant parser if the regular parser can't parse the code.
 

--- a/doc/src/manual.txt
+++ b/doc/src/manual.txt
@@ -529,10 +529,10 @@ type definition>> data structure that the server should load, and its
 `passes` property may hold an object mapping pass names to functions.
 Currently the following passes are supported:
 
-`"preParse" (file, text, partial)`;; Will be run right before a file is parsed,
-and passed the given file, the given text and partial boolean. If the function
-returns a new text value, the origin text will be overriden. This is useful when a
-plugin is able to extract JavaScript content from an HTML file.
+`"preParse" (text, options)`;; Will be run right before a file is parsed,
+and passed the given text and options. If the function
+returns a new text value, the origin text will be overriden. This is useful for instance 
+when a plugin is able to extract JavaScript content from an HTML file.
 
 `"postParse" (ast, text)`;; Will be run right after a file is parsed,
 and passed the parse tree and the parsed file as arguments.

--- a/doc/src/manual.txt
+++ b/doc/src/manual.txt
@@ -529,6 +529,11 @@ type definition>> data structure that the server should load, and its
 `passes` property may hold an object mapping pass names to functions.
 Currently the following passes are supported:
 
+`"preParse" (file, text, partial)`;; Will be run right before a file is parsed,
+and passed the given file, the given text and partial boolean. If the function
+returns a new text value, the origin text will be overriden. This is useful when a
+plugin is able to extract JavaScript content from an HTML file.
+
 `"postParse" (ast, text)`;; Will be run right after a file is parsed,
 and passed the parse tree and the parsed file as arguments.
 

--- a/lib/infer.js
+++ b/lib/infer.js
@@ -1245,8 +1245,12 @@
     if (arr) for (var i = 0; i < arr.length; ++i) arr[i].apply(null, args);
   }
 
-  var parse = exports.parse = function(text, passes, options) {
+  var parse = exports.parse = function(file, text, passes, options) {
     var ast;
+    if (passes.preParse) for (var i = 0; i < passes.preParse.length; i++) {
+      var result = passes.preParse[i](file, text);
+      if (result) text = result;
+    }
     try { ast = acorn.parse(text, options); }
     catch(e) { ast = acorn_loose.parse_dammit(text, options); }
     runPasses(passes, "postParse", ast, text);

--- a/lib/infer.js
+++ b/lib/infer.js
@@ -1245,10 +1245,10 @@
     if (arr) for (var i = 0; i < arr.length; ++i) arr[i].apply(null, args);
   }
 
-  var parse = exports.parse = function(file, text, passes, options) {
+  var parse = exports.parse = function(text, passes, options) {
     var ast;
     if (passes.preParse) for (var i = 0; i < passes.preParse.length; i++) {
-      var result = passes.preParse[i](file, text);
+      var result = passes.preParse[i](text, options);
       if (result) text = result;
     }
     try { ast = acorn.parse(text, options); }

--- a/lib/tern.js
+++ b/lib/tern.js
@@ -73,10 +73,18 @@
   }
   File.prototype.asLineChar = function(pos) { return asLineChar(this, pos); };
 
+  function parse(file, text, srv, partial) {
+    if (srv.passes.preParse) for (var i = 0; i < srv.passes.preParse.length; i++) {
+      var result = srv.passes.preParse[i](file, text, partial);
+      if (result) text = result;
+    }
+    return infer.parse(text, srv.passes, {directSourceFile: file, allowReturnOutsideFunction: true});
+  }
+  
   function updateText(file, text, srv) {
     file.text = srv.options.stripCRs ? text.replace(/\r\n/g, "\n") : text;
     infer.withContext(srv.cx, function() {
-      file.ast = infer.parse(file.text, srv.passes, {directSourceFile: file, allowReturnOutsideFunction: true});
+      file.ast = parse(file, file.text, srv, false);
     });
     file.lineOffsets = null;
   }
@@ -401,7 +409,7 @@
       var scopeStart = infer.scopeAt(realFile.ast, pos, realFile.scope);
       var scopeEnd = infer.scopeAt(realFile.ast, pos + text.length, realFile.scope);
       var scope = file.scope = scopeDepth(scopeStart) < scopeDepth(scopeEnd) ? scopeEnd : scopeStart;
-      file.ast = infer.parse(text, srv.passes, {directSourceFile: file, allowReturnOutsideFunction: true});
+      file.ast = parse(file, text, srv, true);
       infer.analyze(file.ast, file.name, scope, srv.passes);
 
       // This is a kludge to tie together the function types (if any)

--- a/lib/tern.js
+++ b/lib/tern.js
@@ -76,7 +76,7 @@
   function updateText(file, text, srv) {
     file.text = srv.options.stripCRs ? text.replace(/\r\n/g, "\n") : text;
     infer.withContext(srv.cx, function() {
-      file.ast = infer.parse(file, file.text, srv.passes, {directSourceFile: file, allowReturnOutsideFunction: true});
+      file.ast = infer.parse(file.text, srv.passes, {directSourceFile: file, allowReturnOutsideFunction: true});
     });
     file.lineOffsets = null;
   }
@@ -401,7 +401,7 @@
       var scopeStart = infer.scopeAt(realFile.ast, pos, realFile.scope);
       var scopeEnd = infer.scopeAt(realFile.ast, pos + text.length, realFile.scope);
       var scope = file.scope = scopeDepth(scopeStart) < scopeDepth(scopeEnd) ? scopeEnd : scopeStart;
-      file.ast = infer.parse(file, text, srv.passes, {directSourceFile: file, allowReturnOutsideFunction: true});
+      file.ast = infer.parse(text, srv.passes, {directSourceFile: file, allowReturnOutsideFunction: true});
       infer.analyze(file.ast, file.name, scope, srv.passes);
 
       // This is a kludge to tie together the function types (if any)

--- a/lib/tern.js
+++ b/lib/tern.js
@@ -73,18 +73,10 @@
   }
   File.prototype.asLineChar = function(pos) { return asLineChar(this, pos); };
 
-  function parse(file, text, srv, partial) {
-    if (srv.passes.preParse) for (var i = 0; i < srv.passes.preParse.length; i++) {
-      var result = srv.passes.preParse[i](file, text, partial);
-      if (result) text = result;
-    }
-    return infer.parse(text, srv.passes, {directSourceFile: file, allowReturnOutsideFunction: true});
-  }
-  
   function updateText(file, text, srv) {
     file.text = srv.options.stripCRs ? text.replace(/\r\n/g, "\n") : text;
     infer.withContext(srv.cx, function() {
-      file.ast = parse(file, file.text, srv, false);
+      file.ast = infer.parse(file, file.text, srv.passes, {directSourceFile: file, allowReturnOutsideFunction: true});
     });
     file.lineOffsets = null;
   }
@@ -409,7 +401,7 @@
       var scopeStart = infer.scopeAt(realFile.ast, pos, realFile.scope);
       var scopeEnd = infer.scopeAt(realFile.ast, pos + text.length, realFile.scope);
       var scope = file.scope = scopeDepth(scopeStart) < scopeDepth(scopeEnd) ? scopeEnd : scopeStart;
-      file.ast = parse(file, text, srv, true);
+      file.ast = infer.parse(file, text, srv.passes, {directSourceFile: file, allowReturnOutsideFunction: true});
       infer.analyze(file.ast, file.name, scope, srv.passes);
 
       // This is a kludge to tie together the function types (if any)


### PR DESCRIPTION
This PR provides the new `preParse` event which is called before parsing the file.

I'm developping a new tern plugin which is able to :

 * extract JavaScript content from HTML file.
 * provides completion for HTML ids to support that: 

```html
<html>
  <input id="MyId"  />
  <script>
    var input = document.getElementById(" // here Ctrl+Space shows MyId
    input.ch // here Ctrl+Space shows checked because input is an HTML input element
  </script>
</html>
```