### PR TITLE
support top scope references prefixed with a '$'

### DIFF
--- a/plugin/node.js
+++ b/plugin/node.js
@@ -99,8 +99,8 @@
       result = data.modules[name];
     } else if (data.options.modules && data.options.modules.hasOwnProperty(name)) {
       var mod = data.options.modules[name];
-      if (typeof(mod) == "string" && mod.charAt(0) == '$') {
-        result = cx.topScope.props[mod.substring(1)];
+      if (typeof(mod) == "string" && mod.charAt(0) == '=') {
+        result = infer.def.parsePath(mod.slice(1));
       } else {
         var scope = buildWrappingScope(cx.topScope, name);
         infer.def.load(data.options.modules[name], scope);


### PR DESCRIPTION
This approach works with a .tern-project file that looks like this:

```
{
  "libs": [
    "browser",
    "jquery",
    "ScoutData"
  ],
  "plugins": {
    "node": {
      "modules": {
        "ScoutData": "$ScoutData"
      }
    }
  }
}
```

Basically, it scans the context topScope to see if the module value (prefixed with a '$') exists and uses that if it can.