### PR TITLE
Fix promise chaining behavior

### DIFF
--- a/defs/ecma6.json
+++ b/defs/ecma6.json
@@ -10,7 +10,7 @@
       "then": {
         "!doc": "The then() method returns a Promise. It takes two arguments, both are callback functions for the success and failure cases of the Promise.",
         "!url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then",
-        "!type": "fn(onFulfilled: fn(value: ?), onRejected: fn(reason: ?)) -> !this",
+        "!type": "fn(onFulfilled: fn(value: ?), onRejected: fn(reason: ?)) -> !custom:Promise_then",
         "!effects": [
           "call !0 !this.value"
         ]

--- a/lib/def.js
+++ b/lib/def.js
@@ -592,5 +592,21 @@
     return self;
   });
 
+  infer.registerFunction("Promise_then", function(_self, args, argNodes) {
+    var self, fn, retType;
+    if (args && args[0] && (fn = args[0].getFunctionType())) {
+      var retType = args[0].retval.getType();
+      if (retType && retType.name === 'Promise') {
+        self = args[0].retval;
+      } else {
+        self = new infer.Obj(infer.cx().definitions.ecma6["Promise.prototype"]);
+        args[0].retval.propagate(self.defProp("value"));
+      }
+    } else {
+      self = _self;
+    }
+    return self;
+  });
+
   return exports;
 });


### PR DESCRIPTION
Fix the chaining behavior of promise

Sample code:

```js
var pp = new Promise(function (res) {
  res(1);
});
pp.then(function (num) {
  num. // provide number properties
  return '';
}).then(function (str) {
  str // should provide string properties
})
```