### PR TITLE
Support find type for propety key of object literal

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -791,7 +791,7 @@
         (objProp = pointInProp(expr.node, resolvePos(file, query.end)))) ||
         (expr.node.type == "Property" && (objProp = expr.node))) {
       var name = objProp.key.name;
-      if (expr.node.type == "Property") expr = {node: exports.parentNode(objProp, file.ast), state: expr.state};
+      if (expr.node.type == "Property") expr = {node: infer.parentNode(objProp, file.ast), state: expr.state};
       var fromCx = ensureObj(infer.typeFromContext(file.ast, expr));
       if (fromCx && fromCx.hasProp(name)) {
         type = fromCx.hasProp(name);

--- a/lib/tern.js
+++ b/lib/tern.js
@@ -749,8 +749,14 @@
       if (expr) return expr;
       expr = infer.findExpressionAround(file.ast, start, end, file.scope);
       if (expr && (expr.node.type == "ObjectExpression" || wide ||
-                   (start == null ? end : start) - expr.node.start < 20 || expr.node.end - end < 20))
+                   (start == null ? end : start) - expr.node.start < 20 || expr.node.end - end < 20)) {
+        if (expr.node.type == "ObjectExpression" ) {
+          // return object literal property if possible.
+          var objProp = pointInProp(expr.node, end);
+          if (objProp) return {node: objProp, state: expr.state};          
+        }
         return expr;
+      }
       return null;
     }
   };
@@ -781,9 +787,11 @@
     if (!type) throw ternError("No type found at the given position.");
 
     var objProp;
-    if (expr.node.type == "ObjectExpression" && query.end != null &&
-        (objProp = pointInProp(expr.node, resolvePos(file, query.end)))) {
+    if ((expr.node.type == "ObjectExpression" && query.end != null &&
+        (objProp = pointInProp(expr.node, resolvePos(file, query.end)))) ||
+        (expr.node.type == "Property" && (objProp = expr.node))) {
       var name = objProp.key.name;
+      if (expr.node.type == "Property") expr = {node: exports.parentNode(objProp, file.ast), state: expr.state};
       var fromCx = ensureObj(infer.typeFromContext(file.ast, expr));
       if (fromCx && fromCx.hasProp(name)) {
         type = fromCx.hasProp(name);
@@ -801,12 +809,14 @@
     var type = findExprType(srv, query, file, expr), exprType = type;
     if (query.preferFunction)
       type = type.getFunctionType() || type.getType();
-    else
+    else if (expr.node.type != "Property")
       type = type.getType();
 
     if (expr) {
       if (expr.node.type == "Identifier")
         exprName = expr.node.name;
+      else if (expr.node.type == "Property")
+        exprName = expr.node.key.name;
       else if (expr.node.type == "MemberExpression" && !expr.node.computed)
         exprName = expr.node.property.name;
     }


### PR DESCRIPTION
This PR support find type for propety key of object literal. Here a screenshot of find type of RequireJS config of callback property key (when  callback property key is hoverd with mouse inside Eclipse): 

![findtyperequirejsconfig](https://cloud.githubusercontent.com/assets/1932211/9260143/26a911e0-4206-11e5-87e5-0fda8c3aeeb4.png)