### PR TITLE
[node] Use resolveProjectPath + resolveModulePath in an another plugin

### DIFF
--- a/plugin/node.js
+++ b/plugin/node.js
@@ -176,7 +176,9 @@
       currentFile: null,
       currentRequires: [],
       currentOrigin: null,
-      server: server
+      server: server,
+      resolveProjectPath: resolveProjectPath,
+      resolveModulePath: resolveModulePath
     };
 
     server.on("beforeLoad", function(file) {


### PR DESCRIPTION
I'm developping the capability to display list of node modules once the user apply completion https://github.com/angelozerr/tern-guess-types

For that I need to create my own list of modules like https://github.com/marijnh/tern/blob/master/plugin/node.js#L247. So I need resolveProjectPath + resolveModulePath and to avoid copying/pasting your code in lmy tern plugin, I would like to expose it.