### PR TITLE
[node] Provide getModType

### DIFF
--- a/plugin/modules.js
+++ b/plugin/modules.js
@@ -120,6 +120,18 @@
           tern.addCompletion(query, completions, word + added, this.modules[prop])
         }
       }
+    },
+    
+    getModType: function(node) {
+      var modName = this.isModName(node), imp, prop
+      if (imp = this.isImport(node)) {
+        modName = imp.name
+        prop = imp.prop
+      }
+      if (!modName) return type
+
+      var modType = this.resolveModule(modName, node.sourceFile.name)
+      return (prop ? modType.getProp(prop) : modType).getType()
     }
   })
 
@@ -218,15 +230,7 @@
   function findTypeAt(_file, _pos, expr, type) {
     if (!expr) return type
     var me = infer.cx().parent.mod.modules
-    var modName = me.isModName(expr.node), imp, prop
-    if (imp = me.isImport(expr.node)) {
-      modName = imp.name
-      prop = imp.prop
-    }
-    if (!modName) return type
-
-    var modType = me.resolveModule(modName, expr.node.sourceFile.name)
-    modType = (prop ? modType.getProp(prop) : modType).getType()
+    var modType = me.getModType(expr.node)
     if (!modType) return type
 
     // The `type` is a value shared for all string literals.

--- a/plugin/modules.js
+++ b/plugin/modules.js
@@ -128,7 +128,7 @@
         modName = imp.name
         prop = imp.prop
       }
-      if (!modName) return type
+      if (!modName) return
 
       var modType = this.resolveModule(modName, node.sourceFile.name)
       return (prop ? modType.getProp(prop) : modType).getType()


### PR DESCRIPTION
This PR provides teh capability to use getModType from the given node. It is used here for typeAt, but it could be used by another plugin. In my case I would like to use it to validate the required node module.