### PR TITLE
doc_comment: Support string literal object keys [Cannot call method 'charCodeAt' of undefined]

### DIFF
--- a/plugin/doc_comment.js
+++ b/plugin/doc_comment.js
@@ -82,10 +82,13 @@
       },
       ObjectExpression: function(node, scope) {
         for (var i = 0; i < node.properties.length; ++i) {
-          var prop = node.properties[i];
-          if (!prop.computed && prop.commentsBefore)
+          var propName, prop = node.properties[i];
+          if (prop.key.type == 'Literal') { propName = prop.key.value; }
+          else { propName = prop.key.name; }
+
+          if (!prop.computed && prop.commentsBefore && propName)
             interpretComments(prop, prop.commentsBefore, scope,
-                              node.objType.getProp(prop.key.name));
+                              node.objType.getProp(propName));
         }
       },
       Class: function(node, scope) {

--- a/test/cases/docstrings.js
+++ b/test/cases/docstrings.js
@@ -77,7 +77,9 @@ var o = {
   // The name
   name: "Harold",
   // A computed property
-  [1 + 1]: "OK"
+  [1 + 1]: "OK",
+  // A string property
+  'stringProperty': true
 };
 
 // The string "foo".
@@ -86,6 +88,7 @@ o.foo = "foo";
 o.getName; //doc: Get the name.
 o.name; //doc: The name
 o.foo; //doc: The string "foo".
+o.stringProperty; //doc: A string property
 
 class C {
   // The method


### PR DESCRIPTION
Hi,

I was trying out tern and noticed the server kept crashing with this error:

```
/home/dave/dev/build/tern/lib/infer.js:535
    var c0 = str.charCodeAt(0)
                 ^
TypeError: Cannot call method 'charCodeAt' of undefined
    at isInteger (/home/dave/dev/build/tern/lib/infer.js:535:18)
    at extend.hasProp (/home/dave/dev/build/tern/lib/infer.js:569:11)
    at extend.getProp (/home/dave/dev/build/tern/lib/infer.js:601:24)
    at walk.simple.ObjectExpression (/home/dave/dev/build/tern/plugin/doc_comment.js:88:44)
    at c (/home/dave/dev/build/tern/node_modules/acorn/dist/walk.js:39:16)
    at Object.skipThrough (/home/dave/dev/build/tern/node_modules/acorn/dist/walk.js:168:3)
    at c (/home/dave/dev/build/tern/node_modules/acorn/dist/walk.js:38:15)
    at Object.base.VariableDeclarator (/home/dave/dev/build/tern/node_modules/acorn/dist/walk.js:254:18)
    at c (/home/dave/dev/build/tern/node_modules/acorn/dist/walk.js:38:15)
    at Object.base.VariableDeclaration (/home/dave/dev/build/tern/node_modules/acorn/dist/walk.js:249:5)
```

This was caused by `prop.key.name` being undefined in `plugin/doc_comment.js` when an object key is defined as a literal string, e.g.
{
    //Some docstring
    'stringProperty': true
}

This PR fixes that particular case and adds a test case.

Thanks,
Dave