### PR TITLE
Fix https://github.com/marijnh/tern/issues/626 with Windows OS

### DIFF
--- a/plugin/modules.js
+++ b/plugin/modules.js
@@ -197,7 +197,7 @@
   }())
 
   function normPath(name) { 
-    return name.replace(/\\/g, "/")
+    return name ? name.replace(/\\/g, "/") : name
   }
   
   function isRelative(path) {

--- a/plugin/modules.js
+++ b/plugin/modules.js
@@ -187,7 +187,7 @@
         if (/^\./.test(file)) return
         if (filter(filePart, file, query)) {
           var projectPath = path.relative(pDir, path.resolve(dir, file))
-          if (projectPath == parentFile) return
+          if (normPath(projectPath) == normPath(parentFile)) return
           var value = me.modules[projectPath]
           if (/\.js$/.test(file)) file = file.slice(0, file.length - 3)
           tern.addCompletion(query, completions, base + file, value)
@@ -196,6 +196,10 @@
     }
   }())
 
+  function normPath(name) { 
+    return name.replace(/\\/g, "/")
+  }
+  
   function isRelative(path) {
     return /^\.\.?\//.test(path)
   }


### PR DESCRIPTION
This PR fixes https://github.com/marijnh/tern/issues/626 with Windows OS.

```javascript
var projectPath = path.relative(pDir, path.resolve(dir, file))
```

For instance projectPath is equals to  "js\a.js" and is compared to parentFile  "js/a.js" (the test projectPath  == parentFile) returns false)

This PR replace the \ by /