### PR TITLE
Provide basic support for ECMAScript7

### DIFF
--- a/bin/tern
+++ b/bin/tern
@@ -84,6 +84,7 @@ var distDir = path.resolve(__dirname, "..");
 function findDefs(projectDir, config) {
   var defs = [], src = config.libs.slice();
   if (config.ecmaScript) {
+    if (src.indexOf("ecma7") == -1 && config.ecmaVersion >= 7) src.unshift("ecma7")
     if (src.indexOf("ecma6") == -1 && config.ecmaVersion >= 6) src.unshift("ecma6")
     if (src.indexOf("ecma5") == -1) src.unshift("ecma5")
   }   

--- a/defs/ecma7.json
+++ b/defs/ecma7.json
@@ -1,0 +1,19 @@
+{
+  "!name": "ecma7",
+  "Array": {
+    "prototype": {
+      "includes": {
+        "!type": "fn(searchElement: ?, fromIndex?: number) -> bool",
+        "!doc": "The includes() method determines whether an array includes a certain element, returning true or false as appropriate.",
+        "!url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes"
+      }
+    }
+  },
+  "ArrayBuffer": {
+    "transfer": {
+      "!type": "fn(oldBuffer: +ArrayBuffer, newByteLength?: number) -> +ArrayBuffer",
+      "!doc": "The static ArrayBuffer.transfer() method returns a new ArrayBuffer whose contents are taken from the oldBuffer's data and then is either truncated or zero-extended by newByteLength. If newByteLength is undefined, the byteLength of the oldBuffer is used. This operation leaves oldBuffer in a detached state.",
+      "!url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transfer"
+    }
+  }
+}


### PR DESCRIPTION
This PR provides a basic `ECMAScript7` : 

 * Initialize `ecma7.json` with new methods `Array.prototype.includes` & `ArrayBuffer.transfer`
 * load the def ecma7 if ecmaVersion is set to 7.