### PR TITLE
Add from start/end of the node where find definition is executed

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -922,7 +922,7 @@
     if (infer.didGuess()) return {};
 
     var span = getSpan(type);
-    var result = {url: type.url, doc: parseDoc(query, type.doc), origin: type.origin};
+    var result = {url: type.url, doc: parseDoc(query, type.doc), origin: type.origin, fromStart: expr.node.start, fromEnd: expr.node.end};
 
     if (type.types) for (var i = type.types.length - 1; i >= 0; --i) {
       var tp = type.types[i];


### PR DESCRIPTION
In Eclipse Tern IDE, when user wish to find definition, it uses Ctrl+Click on a node which call findDef (it is called Hyperlink). I need to underline this node and this PR gives me the capability to find the start/end of the node to underline.

This PR is simple, but after it should be cool to improve it to customize the from start/end like typeAt.