### PR TITLE
Fix failing tests on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/**/* text eol=lf

--- a/lib/tern.js
+++ b/lib/tern.js
@@ -206,7 +206,7 @@
     },
 
     normalizeFilename: function(name) {
-      var norm = this.options.normalizeFilename(name).replace(/\\/g, "//")
+      var norm = this.options.normalizeFilename(name).replace(/\\/g, "/")
       if (norm.indexOf(this.projectDir) == 0) norm = norm.slice(this.projectDir.length)
       return norm
     }


### PR DESCRIPTION
Tests on my Windows 7 machine failed with errors similar to #331.

I've found two issues:

1. my repository was checked out with CRLF line endings, but test runners expect files with LF.
I think the easiest solution is to add .gitattributes file, so that test files are always checked out with LF line endings.

2. typo in `normalizeFilename()`

After these changes all tests are passing.

